### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/gabrielebrunori/32706370-69c9-42be-bb3e-ebc44421e7cc/fe41d1db-f853-4841-956f-308bfbda8968/_apis/work/boardbadge/67b9252f-2b34-4d5c-859d-2e50328506dd)](https://dev.azure.com/gabrielebrunori/32706370-69c9-42be-bb3e-ebc44421e7cc/_boards/board/t/fe41d1db-f853-4841-956f-308bfbda8968/Microsoft.RequirementCategory)
 Scacchi Painter Universal
 =========================
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#182](https://dev.azure.com/gabrielebrunori/32706370-69c9-42be-bb3e-ebc44421e7cc/_workitems/edit/182). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.