### PR TITLE
Update build and deploy job

### DIFF
--- a/.github/workflows/azure-static-web-apps-orange-sea-080bc3503.yml
+++ b/.github/workflows/azure-static-web-apps-orange-sea-080bc3503.yml
@@ -10,8 +10,37 @@ on:
       - master
 
 jobs:
-  build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+  build_and_deploy_job_prerelease:
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    name: Build and Deploy Job (prerelease)
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: actions/setup-node@v4
+        with:
+          node-version: latest
+          check-latest: true
+      - name: Build And Deploy
+        id: builddeploy
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_ORANGE_SEA_080BC3503 }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
+          action: "upload"
+          ###### Repository/Build Configurations - These values can be configured to match you app requirements. ######
+          # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
+          app_location: "/src/Gui/sp-gui.html/sp-gui-angular" # App source code path
+          api_location: "api" # Api source code path - optional
+          output_location: "dist/gui" # Built app content directory - optional
+          ###### End of Repository/Build Configurations ######
+          app_build_command: "yarn build:Azure"
+          deployment_environment: "release"
+          skip_api_build: true
+
+  build_and_deploy_job_release:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
@@ -36,8 +65,9 @@ jobs:
           output_location: "dist/gui" # Built app content directory - optional
           ###### End of Repository/Build Configurations ######
           app_build_command: "yarn build:Azure"
-          deployment_environment: "release"
-          
+          deployment_environment: "Production"
+          skip_api_build: true
+
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,6 @@
 # Scacchi Painter Universal
 
-[![Board Status](https://dev.azure.com/gabrielebrunori/32706370-69c9-42be-bb3e-ebc44421e7cc/fe41d1db-f853-4841-956f-308bfbda8968/_apis/work/boardbadge/67b9252f-2b34-4d5c-859d-2e50328506dd)](https://dev.azure.com/gabrielebrunori/32706370-69c9-42be-bb3e-ebc44421e7cc/_boards/board/t/fe41d1db-f853-4841-956f-308bfbda8968/Microsoft.RequirementCategory)
-
-[![Build Status](https://dev.azure.com/gabrielebrunori/Accademia%20Del%20Problema/_apis/build/status/dardino.scacchi-painter?branchName=master)](https://dev.azure.com/gabrielebrunori/Accademia%20Del%20Problema/_build/latest?definitionId=9&branchName=master)
-![GitHub Action](https://github.com/dardino/scacchi-painter/actions/workflows/azure-static-web-apps-orange-sea-080bc3503.yml/badge.svg)
+[![Board Status](https://dev.azure.com/gabrielebrunori/32706370-69c9-42be-bb3e-ebc44421e7cc/fe41d1db-f853-4841-956f-308bfbda8968/_apis/work/boardbadge/67b9252f-2b34-4d5c-859d-2e50328506dd)](https://dev.azure.com/gabrielebrunori/32706370-69c9-42be-bb3e-ebc44421e7cc/_boards/board/t/fe41d1db-f853-4841-956f-308bfbda8968/Microsoft.RequirementCategory)[![Build Status](https://dev.azure.com/gabrielebrunori/Accademia%20Del%20Problema/_apis/build/status/dardino.scacchi-painter?branchName=master)](https://dev.azure.com/gabrielebrunori/Accademia%20Del%20Problema/_build/latest?definitionId=9&branchName=master)[![GitHub Action](https://github.com/dardino/scacchi-painter/actions/workflows/azure-static-web-apps-orange-sea-080bc3503.yml/badge.svg)](https://github.com/dardino/scacchi-painter/actions)
 
 A new cross-platform engine and gui for chess problem composers
 


### PR DESCRIPTION
This pull request updates the build and deploy job in the GitHub Actions workflow. It adds a new job called "build_and_deploy_job_prerelease" that runs when a pull request is opened or synchronized. This job skips the API build and deploys the app to the "release" environment. Additionally, it adds a new job called "build_and_deploy_job_release" that runs when a push event occurs. This job also skips the API build and deploys the app to the "Production" environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Renamed and updated the build and deploy job for pre-release.
  - Added a new build and deploy job for release events.

- **Documentation**
  - Consolidated multiple badge links into a single line in the README for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->