### PR TITLE
Fix traverse number calculation in ChessboardComponent

### DIFF
--- a/src/Gui/sp-gui.html/sp-gui-angular/@sp/chessboard/src/lib/chessboard.component.ts
+++ b/src/Gui/sp-gui.html/sp-gui-angular/@sp/chessboard/src/lib/chessboard.component.ts
@@ -43,9 +43,8 @@ export class ChessboardComponent
   }
 
   getTraverse(location: SquareLocation) {
-    return Traverse.indexOf(location.traverse) + 1;
+    return 8 - Traverse.indexOf(location.traverse);
   }
-
 
   @ViewChild("canvas", { static: true })
   canvas: ElementRef;


### PR DESCRIPTION
Adjust the calculation for traverse numbers to ensure correct indexing in the ChessboardComponent.